### PR TITLE
Added stock market plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,10 @@ Prayer time for Algeria, Oran :
  Asr 15:38
  Maghrib 17:56
  Isha 19:22
-
-
+```
+Check the stock market : 
+```bash
+$ sarah marketwatch yamaha jp all
 ```
 # Roadmap
 - add autotools support

--- a/plugins/marketwatch/marketwatch.plugin
+++ b/plugins/marketwatch/marketwatch.plugin
@@ -1,0 +1,5 @@
+[Plugin]
+Module=marketwatch
+Loader=python3
+Name=marketwatch
+Description=let sarah get the market shares via marketwatch for you

--- a/plugins/marketwatch/marketwatch.py
+++ b/plugins/marketwatch/marketwatch.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#  marketwatch.py
+#
+#  Copyright 2016 Semicode Inc <aye7@archost>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#
+import sys
+import webbrowser
+import gi
+gi.require_version('Peas', '1.0')
+gi.require_version('Sarah', '1.0')
+from gi.repository import GObject, Peas, Sarah
+
+
+class MarketWatchPlugin(GObject.Object, Sarah.IExtension):
+    __gtype_name__ = 'MarketWatchPlugin'
+
+    object = GObject.property(type=GObject.Object)
+
+    def do_activate(self, args, argv):
+        lookup_term = ''
+        country = ''
+        security_type = ''
+        base_url ="http://www.marketwatch.com/tools/quotes/lookup.asp?siteID=mktw&Lookup=" 
+        if 1 <= argv <= 3:
+            if argv == 1:
+                lookup_term = args[0].title()
+                url = base_url + lookup_term
+            elif argv == 2:
+                lookup_term = args[0].title()
+                country = args[1].title()
+                url = base_url + lookup_term + "&Country=" + country
+            elif argv == 3:
+                lookup_term = args[0].title()
+                country = args[1].title()
+                security_type = args[2].title()
+                url = base_url + lookup_term + "&Country=" + country + "&Type=" + security_type
+            webbrowser.open(url)
+
+        else:
+            print("Usage: sarah marketwatch lookup_term [country] [security_type]")
+
+    def do_deactivate(self):
+       pass

--- a/plugins/marketwatch/marketwatch_useguide.md
+++ b/plugins/marketwatch/marketwatch_useguide.md
@@ -1,0 +1,40 @@
+### Stock Market lookup plugin for Sarah 
+
+Make Sarah check the stock market for you using [marketwatch.com](http://www.marketwatch.com/)
+
+usage : 
+```bash
+$ sarah marketwatch lookup_term [country] [security_type]
+```
+example : 
+```bash
+$ sarah marketwatch googl us stock
+$ sarah marketwatch yamaha jp
+$ sarah marketwatch AMD
+```
+
+#### country options
+`country_option` | actual country name
+* `us` | United States of America (default)
+* `all` | All countries
+* `ca` | Canada
+* `au` | Australia
+* `fr` | France
+* `de` | Germany
+* `hk` | Hong Kong
+* `it` | Italy
+* `jp` | Japan
+* `nl` | Netherlands 
+* `nz` | New Zealand
+* `no` | Norway
+* `za` | South Africa
+* `es` | Spain
+* `se` | Sweden
+* `ch` | Switzerland
+* `uk` | United Kingdom
+#### security_type options
+* `All` (default)
+* `Stock`
+* `Fund`
+* `Index` 
+* `Currency`


### PR DESCRIPTION
I made a plugin that opens a new webpage to look up for the stock market.
There's a new md file in the marketwatch directory it contains the use guide for the plugin, I didn't want to include all of the guide in the `README.md` because it would clutter it up

if adding _`marketwatch_useguide.md` was a bad move, just ignore the last commit `2a855a8`
_`marketwatch_useguide.md` contains the following:_

### Stock Market lookup plugin for Sarah 

Make Sarah check the stock market for you using [marketwatch.com](http://www.marketwatch.com/)

usage : 
```bash
$ sarah marketwatch lookup_term [country] [security_type]
```
example : 
```bash
$ sarah marketwatch googl us stock
$ sarah marketwatch yamaha jp
$ sarah marketwatch AMD
```

#### country options
`country_option` | actual country name
* `us` | United States of America (default)
* `all` | All countries
* `ca` | Canada
* `au` | Australia
* `fr` | France
* `de` | Germany
* `hk` | Hong Kong
* `it` | Italy
* `jp` | Japan
* `nl` | Netherlands 
* `nz` | New Zealand
* `no` | Norway
* `za` | South Africa
* `es` | Spain
* `se` | Sweden
* `ch` | Switzerland
* `uk` | United Kingdom
#### security_type options
* `All` (default)
* `Stock`
* `Fund`
* `Index` 
* `Currency`