### PR TITLE
Add Wiki Plugin for German Language

### DIFF
--- a/plugins/wiki/wiki.plugin
+++ b/plugins/wiki/wiki.plugin
@@ -2,5 +2,5 @@
 Module=wiki
 Loader=python3
 Name=wiki
-Description=get small bio about anyone you want
+Description=get a short summary of german wikipedia
 

--- a/plugins/wiki/wiki.plugin
+++ b/plugins/wiki/wiki.plugin
@@ -1,0 +1,6 @@
+[Plugin]
+Module=wiki
+Loader=python3
+Name=wiki
+Description=get small bio about anyone you want
+

--- a/plugins/wiki/wiki.py
+++ b/plugins/wiki/wiki.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  Wiki.py
+#
+#  Copyright 2016 Semicode Inc <aye7@archost>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA 02110-1301, USA.
+#
+#
+import wikipedia
+import gi
+gi.require_version('Peas', '1.0')
+gi.require_version('Sarah', '1.0')
+from gi.repository import GObject, Peas, Sarah
+
+
+class WikiPlugin(GObject.Object, Sarah.IExtension):
+    __gtype_name__ = 'WikiPlugin'
+
+    object = GObject.property(type=GObject.Object)
+
+    def do_activate(self, args, argv):
+        wikipedia.set_lang("de")
+        print(wikipedia.summary(' '.join(args), sentences=2))
+
+    def do_deactivate(self):
+        pass


### PR DESCRIPTION
I added "wiki" as plugin for the german language. It is similar to the "whois" plugin, but I used the function not only for biographies and I wanted the german entries of wikipedia.

usage:
`$ sarah wiki keyword`

example:
`$ sarah wiki Datenbanken`